### PR TITLE
[BUGFIX] Correct parameters order

### DIFF
--- a/Service/MediaResolver.php
+++ b/Service/MediaResolver.php
@@ -178,7 +178,7 @@ class MediaResolver implements \MageSuite\ContentConstructor\Service\MediaResolv
             $srcSet[] = $this->buildSrcSetElement($this->getUrlByPath($resizedFilePath), $resizedImageWidth);
         }
 
-        return implode($srcSet, ', ');
+        return implode(', ', $srcSet);
     }
 
     /**


### PR DESCRIPTION
Exception #0 (Exception): Deprecated Functionality: implode(): Passing glue string after array is deprecated. Swap the parameters in .../vendor/creativestyle/magesuite-content-constructor-frontend/Service/MediaResolver.php on line 181